### PR TITLE
Fix typo when checking respondsToSelector.

### DIFF
--- a/BeamMusicPlayerExample/Source/BeamMusicPlayerViewController.m
+++ b/BeamMusicPlayerExample/Source/BeamMusicPlayerViewController.m
@@ -332,7 +332,7 @@
  */
 -(void)changeTrack:(NSUInteger)newTrack {
     BOOL shouldChange = YES;
-    if ( [self.delegate respondsToSelector:@selector(musicPlayer:shoulChangeTrack:) ]){
+    if ( [self.delegate respondsToSelector:@selector(musicPlayer:shouldChangeTrack:) ]){
         shouldChange = [self.delegate musicPlayer:self shouldChangeTrack:newTrack];
     }
     


### PR DESCRIPTION
Fixed typo when checking for the wrong selector `musicPlayer:shoulChangeTrack:`. Now checking `musicPlayer:shouldChangeTrack:`.
